### PR TITLE
invert button signal

### DIFF
--- a/GPIO.py
+++ b/GPIO.py
@@ -46,7 +46,7 @@ def ButtonHandeler(channel):
     Args:
         channel(int):  The RPi GPIO channel used for monitoring the button
     """
-    if GPIO.input(channel) == GPIO.HIGH:
+    if GPIO.input(channel) == GPIO.LOW:
         set("Button","Pressed")
     else:
         set("Button","Released")


### PR DESCRIPTION
The "button is pressed" and "button is released" dialogs seemed to be the wrong way round - at least for a RPi 4. This inverts change inverts the input signal read from the button.